### PR TITLE
Use YYYY-MM-DD date format in XML output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/snabb/sitemap
+module github.com/semantosoph/sitemap
+
+go 1.15
 
 require github.com/snabb/diagio v1.0.0

--- a/sitemap.go
+++ b/sitemap.go
@@ -7,10 +7,17 @@ package sitemap
 
 import (
 	"encoding/xml"
-	"github.com/snabb/diagio"
+	"fmt"
 	"io"
 	"time"
+
+	"github.com/snabb/diagio"
 )
+
+// Date specifies a proxy time object that we use to define our own XML encoder.
+type Date struct {
+	time.Time
+}
 
 // ChangeFreq specifies change frequency of a sitemap entry. It is just a string.
 type ChangeFreq string
@@ -33,7 +40,7 @@ const (
 // using with a sitemap index.
 type URL struct {
 	Loc        string     `xml:"loc"`
-	LastMod    *time.Time `xml:"lastmod,omitempty"`
+	LastMod    Date       `xml:"lastmod,omitempty"`
 	ChangeFreq ChangeFreq `xml:"changefreq,omitempty"`
 	Priority   float32    `xml:"priority,omitempty"`
 }
@@ -93,3 +100,11 @@ func (s *Sitemap) ReadFrom(r io.Reader) (n int64, err error) {
 }
 
 var _ io.ReaderFrom = (*Sitemap)(nil)
+
+// MarshalXML marshals LastMod into the correct format
+func (d Date) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	dateString := fmt.Sprintf("%v", time.Time(d.Time).Format("2006-01-02"))
+	e.EncodeElement(dateString, start)
+
+	return nil
+}

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -1,9 +1,10 @@
 package sitemap_test
 
 import (
-	"github.com/snabb/sitemap"
 	"os"
 	"time"
+
+	"github.com/semantosoph/sitemap"
 )
 
 func Example() {
@@ -11,7 +12,7 @@ func Example() {
 	t := time.Unix(0, 0).UTC()
 	sm.Add(&sitemap.URL{
 		Loc:        "http://example.com/",
-		LastMod:    &t,
+		LastMod:    sitemap.Date{t},
 		ChangeFreq: sitemap.Daily,
 	})
 	sm.WriteTo(os.Stdout)
@@ -20,7 +21,7 @@ func Example() {
 	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	//   <url>
 	//     <loc>http://example.com/</loc>
-	//     <lastmod>1970-01-01T00:00:00Z</lastmod>
+	//     <lastmod>1970-01-01</lastmod>
 	//     <changefreq>daily</changefreq>
 	//   </url>
 	// </urlset>

--- a/sitemapindex.go
+++ b/sitemapindex.go
@@ -2,8 +2,9 @@ package sitemap
 
 import (
 	"encoding/xml"
-	"github.com/snabb/diagio"
 	"io"
+
+	"github.com/snabb/diagio"
 )
 
 // SitemapIndex is like Sitemap except the elements are named differently

--- a/sitemapindex_test.go
+++ b/sitemapindex_test.go
@@ -1,9 +1,10 @@
 package sitemap_test
 
 import (
-	"github.com/snabb/sitemap"
 	"os"
 	"time"
+
+	"github.com/semantosoph/sitemap"
 )
 
 func ExampleSitemapIndex() {
@@ -11,7 +12,7 @@ func ExampleSitemapIndex() {
 	t := time.Unix(0, 0).UTC()
 	smi.Add(&sitemap.URL{
 		Loc:     "http://example.com/sitemap-1.xml",
-		LastMod: &t,
+		LastMod: sitemap.Date{t},
 	})
 	smi.WriteTo(os.Stdout)
 	// Output:
@@ -19,7 +20,7 @@ func ExampleSitemapIndex() {
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	//   <sitemap>
 	//     <loc>http://example.com/sitemap-1.xml</loc>
-	//     <lastmod>1970-01-01T00:00:00Z</lastmod>
+	//     <lastmod>1970-01-01</lastmod>
 	//   </sitemap>
 	// </sitemapindex>
 }


### PR DESCRIPTION
Google apparently only accepts date format YYYY-MM-DD in LastMod field which is incompatible with the Time.time used here.