### PR TITLE
Improve sitemap writer defaults and drop diagio

### DIFF
--- a/counterwriter.go
+++ b/counterwriter.go
@@ -1,0 +1,33 @@
+package sitemap
+
+import (
+	"io"
+)
+
+// CounterWriter implements [io.Writer]. Number of bytes written is tracked.
+type CounterWriter struct {
+	writer io.Writer
+	count  int64
+}
+
+var _ io.Writer = (*CounterWriter)(nil)
+
+// NewCounterWriter wraps [io.Writer] and returns [CounterWriter].
+func NewCounterWriter(w io.Writer) (cw *CounterWriter) {
+	return &CounterWriter{
+		writer: w,
+	}
+}
+
+// Write calls Write on the wrapped [io.Writer] and adds the number of bytes
+// written to the counter.
+func (cw *CounterWriter) Write(p []byte) (n int, err error) {
+	n, err = cw.writer.Write(p)
+	cw.count = cw.count + int64(n)
+	return n, err
+}
+
+// Count returns the number of bytes written to the [CounterWriter].
+func (cw *CounterWriter) Count() (n int64) {
+	return cw.count
+}

--- a/counterwriter_test.go
+++ b/counterwriter_test.go
@@ -1,0 +1,17 @@
+package sitemap_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/snabb/sitemap"
+)
+
+func ExampleCounterWriter() {
+	cw := sitemap.NewCounterWriter(os.Stdout)
+	fmt.Fprintln(cw, "hello world")
+	fmt.Println(cw.Count())
+	// Output:
+	// hello world
+	// 12
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/snabb/sitemap
 
 go 1.19
 
-require github.com/snabb/diagio v1.0.4
-
 require github.com/go-test/deep v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/snabb/diagio v1.0.4 h1:XnlKoBarZWiAEnNBYE5t1nbvJhdaoTaW7IBzu0R4AqM=
-github.com/snabb/diagio v1.0.4/go.mod h1:Y+Pja4UJrskCOKaLxOfa8b8wYSVb0JWpR4YFNHuzjDI=

--- a/sitemap.go
+++ b/sitemap.go
@@ -9,8 +9,6 @@ import (
 	"encoding/xml"
 	"io"
 	"time"
-
-	"github.com/snabb/diagio"
 )
 
 const defaultXMLNS = "http://www.sitemaps.org/schemas/sitemap/0.9"
@@ -71,7 +69,7 @@ func (s *Sitemap) Add(u *URL) {
 // WriteTo writes XML encoded sitemap to given [io.Writer].
 // Implements [io.WriterTo].
 func (s *Sitemap) WriteTo(w io.Writer) (n int64, err error) {
-	cw := diagio.NewCounterWriter(w)
+	cw := NewCounterWriter(w)
 
 	if s.Xmlns == "" {
 		s.Xmlns = defaultXMLNS

--- a/sitemap.go
+++ b/sitemap.go
@@ -13,6 +13,8 @@ import (
 	"github.com/snabb/diagio"
 )
 
+const defaultXMLNS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
 // ChangeFreq specifies change frequency of a [Sitemap] or [SitemapIndex]
 // [URL] entry. It is just a string.
 type ChangeFreq string
@@ -56,7 +58,7 @@ type Sitemap struct {
 // New returns a new [Sitemap].
 func New() *Sitemap {
 	return &Sitemap{
-		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		Xmlns: defaultXMLNS,
 		URLs:  make([]*URL, 0),
 	}
 }
@@ -70,6 +72,10 @@ func (s *Sitemap) Add(u *URL) {
 // Implements [io.WriterTo].
 func (s *Sitemap) WriteTo(w io.Writer) (n int64, err error) {
 	cw := diagio.NewCounterWriter(w)
+
+	if s.Xmlns == "" {
+		s.Xmlns = defaultXMLNS
+	}
 
 	_, err = cw.Write([]byte(xml.Header))
 	if err != nil {

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -100,6 +100,20 @@ func TestSitemap_WriteToError(t *testing.T) {
 	}
 }
 
+func TestSitemap_WriteToSetsDefaultXMLNS(t *testing.T) {
+	sm := new(sitemap.Sitemap)
+	sm.Add(&sitemap.URL{Loc: "http://example.com/"})
+
+	buf := new(bytes.Buffer)
+	if _, err := sm.WriteTo(buf); err != nil {
+		t.Fatalf("WriteTo returned error: %v", err)
+	}
+
+	if got, want := sm.Xmlns, "http://www.sitemaps.org/schemas/sitemap/0.9"; got != want {
+		t.Fatalf("Xmlns = %q, want %q", got, want)
+	}
+}
+
 func TestSitemap_ReadFrom(t *testing.T) {
 	sm1 := sitemap.New()
 

--- a/sitemapindex.go
+++ b/sitemapindex.go
@@ -24,7 +24,7 @@ type SitemapIndex struct {
 // NewSitemapIndex returns new [SitemapIndex].
 func NewSitemapIndex() *SitemapIndex {
 	return &SitemapIndex{
-		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
+		Xmlns: defaultXMLNS,
 		URLs:  make([]*URL, 0),
 	}
 }
@@ -38,6 +38,10 @@ func (s *SitemapIndex) Add(u *URL) {
 // Implements [io.WriterTo].
 func (s *SitemapIndex) WriteTo(w io.Writer) (n int64, err error) {
 	cw := diagio.NewCounterWriter(w)
+
+	if s.Xmlns == "" {
+		s.Xmlns = defaultXMLNS
+	}
 
 	_, err = cw.Write([]byte(xml.Header))
 	if err != nil {
@@ -55,7 +59,7 @@ func (s *SitemapIndex) WriteTo(w io.Writer) (n int64, err error) {
 	return cw.Count(), err
 }
 
-var _ io.WriterTo = (*Sitemap)(nil)
+var _ io.WriterTo = (*SitemapIndex)(nil)
 
 // ReadFrom reads and parses an XML encoded sitemap index from [io.Reader].
 // Implements [io.ReaderFrom].
@@ -65,4 +69,4 @@ func (s *SitemapIndex) ReadFrom(r io.Reader) (n int64, err error) {
 	return de.InputOffset(), err
 }
 
-var _ io.ReaderFrom = (*Sitemap)(nil)
+var _ io.ReaderFrom = (*SitemapIndex)(nil)

--- a/sitemapindex.go
+++ b/sitemapindex.go
@@ -3,8 +3,6 @@ package sitemap
 import (
 	"encoding/xml"
 	"io"
-
-	"github.com/snabb/diagio"
 )
 
 // SitemapIndex is like [Sitemap] except the elements are named differently
@@ -37,7 +35,7 @@ func (s *SitemapIndex) Add(u *URL) {
 // WriteTo writes XML encoded sitemap index to given [io.Writer].
 // Implements [io.WriterTo].
 func (s *SitemapIndex) WriteTo(w io.Writer) (n int64, err error) {
-	cw := diagio.NewCounterWriter(w)
+	cw := NewCounterWriter(w)
 
 	if s.Xmlns == "" {
 		s.Xmlns = defaultXMLNS

--- a/sitemapindex_test.go
+++ b/sitemapindex_test.go
@@ -44,6 +44,20 @@ func TestSitemapIndex_WriteToError(t *testing.T) {
 	}
 }
 
+func TestSitemapIndex_WriteToSetsDefaultXMLNS(t *testing.T) {
+	smi := new(sitemap.SitemapIndex)
+	smi.Add(&sitemap.URL{Loc: "http://example.com/sitemap.xml"})
+
+	buf := new(bytes.Buffer)
+	if _, err := smi.WriteTo(buf); err != nil {
+		t.Fatalf("WriteTo returned error: %v", err)
+	}
+
+	if got, want := smi.Xmlns, "http://www.sitemaps.org/schemas/sitemap/0.9"; got != want {
+		t.Fatalf("Xmlns = %q, want %q", got, want)
+	}
+}
+
 func TestSitemapIndex_ReadFrom(t *testing.T) {
 	smi1 := sitemap.NewSitemapIndex()
 


### PR DESCRIPTION
## Summary
- fix the sitemap index interface assertions and default the XML namespace for zero-value writers
- add tests covering the default namespace behavior
- vendor a local counter writer and remove the external github.com/snabb/diagio dependency

## Testing
- go test ./...