### PR TITLE
Update CI actions to latest versions and add Codecov token

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 'stable'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
 
       - name: Build
         run: go build -v ./...
@@ -25,4 +25,6 @@ jobs:
         run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/snabb/sitemap
 
-go 1.19
+go 1.21
 
 require github.com/go-test/deep v1.1.0


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v3 → v4, `actions/setup-go` v3 → v5, `golangci/golangci-lint-action` v3 → v6, `codecov/codecov-action` v3 → v5
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to the Codecov upload step
- Bump minimum Go version in `go.mod` from 1.19 to 1.21

## Notes

A `CODECOV_TOKEN` repository secret needs to be set in GitHub Settings → Secrets → Actions for the Codecov upload to authenticate properly.

## Test plan

- [ ] CI passes on this PR
- [ ] Codecov upload succeeds with token

🤖 Generated with [Claude Code](https://claude.com/claude-code)